### PR TITLE
Make ignoring directories configurable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rake-notes (0.2.0)
+    rake-notes (0.2.1)
       colored
       rake
 
@@ -26,3 +26,6 @@ PLATFORMS
 DEPENDENCIES
   rake-notes!
   rspec
+
+BUNDLED WITH
+   1.16.0

--- a/lib/rake/notes/version.rb
+++ b/lib/rake/notes/version.rb
@@ -1,5 +1,5 @@
 module Rake
   module Notes
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
I have run into several issues where rake-notes is displaying things contained in dependent code. For example, our continuous integration process installs gems in `./vendor/bundle` and rake-notes was picking it up. I've added `./bundle` and `./vendor/bundle` to the default ignore list.

I also have a few cases where I have other directories I want to ignore (e.g. /docs when that is a separate project checked out as a submodule). It seems best just to make it configurable so I did just that. You can add a `.rake-notes.yml` file with a list of directories to ignore.